### PR TITLE
Fixed misleading documentation on fsync

### DIFF
--- a/src/fusemt.rs
+++ b/src/fusemt.rs
@@ -413,7 +413,7 @@ pub trait FilesystemMT {
     /// * `path`: path to the file.
     /// * `mask`: mode bits to check for access to.
     ///
-    /// Return `Ok(())` if all requested permissions are allowed, otherwise return `Err(EACCESS)`
+    /// Return `Ok(())` if all requested permissions are allowed, otherwise return `Err(EACCES)`
     /// or other error code as appropriate (e.g. `ENOENT` if the file doesn't exist).
     fn access(&self, _req: RequestInfo, _path: &Path, _mask: u32) -> ResultEmpty {
         Err(libc::ENOSYS)

--- a/src/fusemt.rs
+++ b/src/fusemt.rs
@@ -308,7 +308,7 @@ pub trait FilesystemMT {
     ///
     /// * `path`: path to the file.
     /// * `fh`: file handle returned from the `open` call.
-    /// * `datasync`: if `false`, just write metadata, otherwise also write file data.
+    /// * `datasync`: if `false`, also write metadata, otherwise just write file data.
     fn fsync(&self, _req: RequestInfo, _path: &Path, _fh: u64, _datasync: bool) -> ResultEmpty {
         Err(libc::ENOSYS)
     }


### PR DESCRIPTION
rust-fuse says that if `_datasync` is non-zero (i.e. `true`), then only data should be synced, and not metadata. Otherwise, both data and metadata should be synced. I corroborated that with libfuse documentation.
Here, previously the documentation said it should be just metadata on `false`, and both on `true`. Now it says the same as above.