### PR TITLE
Change read() to use a callback

### DIFF
--- a/src/fusemt.rs
+++ b/src/fusemt.rs
@@ -323,10 +323,12 @@ impl<T: FilesystemMT + Sync + Send + 'static> fuse::Filesystem for FuseMT<T> {
         let target = self.target.clone();
         let req_info = req.info();
         self.threadpool_run(move || {
-            match target.read(req_info, &path, fh, offset as u64, size) {
-                Ok(ref data) => reply.data(data),
-                Err(e) => reply.error(e),
-            }
+            target.read(req_info, &path, fh, offset as u64, size, |result| {
+                match result {
+                    Ok(data) => reply.data(data),
+                    Err(e) => reply.error(e),
+                }
+            });
         });
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -281,8 +281,8 @@ pub trait FilesystemMT {
     /// * `size`: number of bytes to read.
     ///
     /// Return the bytes read.
-    fn read(&self, _req: RequestInfo, _path: &Path, _fh: u64, _offset: u64, _size: u32) -> ResultData {
-        Err(libc::ENOSYS)
+    fn read(&self, _req: RequestInfo, _path: &Path, _fh: u64, _offset: u64, _size: u32, result: impl FnOnce(Result<&[u8], libc::c_int>)) {
+        result(Err(libc::ENOSYS))
     }
 
     /// Write to a file.


### PR DESCRIPTION
This avoids forcing implementations to allocate a Vec,
which is important for high performance implementations