### PR TITLE
Update example to rust 2018 edition

### DIFF
--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -2,6 +2,7 @@
 name = "passthrufs"
 version = "0.1.0"
 authors = ["William R. Fraser <wfraser@codewise.org>"]
+edition = "2018"
 workspace = ".."
 
 [dependencies]

--- a/example/src/libc_extras.rs
+++ b/example/src/libc_extras.rs
@@ -132,7 +132,7 @@ pub mod libc {
                 if stat.is_none() {
                     let path_c = unsafe { CStr::from_ptr(path) } .to_owned();
                     let path_os = OsString::from_vec(path_c.into_bytes());
-                    *stat = Some(try!(libc_wrappers::lstat(path_os)));
+                    *stat = Some(libc_wrappers::lstat(path_os)?);
                 }
                 Ok(())
             }

--- a/example/src/libc_wrappers.rs
+++ b/example/src/libc_wrappers.rs
@@ -8,7 +8,7 @@ use std::io;
 use std::mem;
 use std::ptr;
 use std::os::unix::ffi::OsStringExt;
-use libc_extras::libc;
+use crate::libc_extras::libc;
 
 macro_rules! into_cstring {
     ($path:expr, $syscall:expr) => {

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -6,13 +6,8 @@
 use std::env;
 use std::ffi::{OsStr, OsString};
 
-extern crate libc;
-extern crate time;
-
 #[macro_use]
 extern crate log;
-
-extern crate fuse_mt;
 
 mod libc_extras;
 mod libc_wrappers;

--- a/example/src/passthrough.rs
+++ b/example/src/passthrough.rs
@@ -12,8 +12,8 @@ use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::os::unix::io::{FromRawFd, IntoRawFd};
 use std::path::{Path, PathBuf};
 
-use super::libc_extras::libc;
-use super::libc_wrappers;
+use crate::libc_extras::libc;
+use crate::libc_wrappers;
 
 use fuse_mt::*;
 use time::*;
@@ -609,11 +609,11 @@ impl FilesystemMT for PassthroughFS {
         if size > 0 {
             let mut data = Vec::<u8>::with_capacity(size as usize);
             unsafe { data.set_len(size as usize) };
-            let nread = try!(libc_wrappers::llistxattr(real, data.as_mut_slice()));
+            let nread = libc_wrappers::llistxattr(real, data.as_mut_slice())?;
             data.truncate(nread);
             Ok(Xattr::Data(data))
         } else {
-            let nbytes = try!(libc_wrappers::llistxattr(real, &mut[]));
+            let nbytes = libc_wrappers::llistxattr(real, &mut[])?;
             Ok(Xattr::Size(nbytes as u32))
         }
     }
@@ -626,11 +626,11 @@ impl FilesystemMT for PassthroughFS {
         if size > 0 {
             let mut data = Vec::<u8>::with_capacity(size as usize);
             unsafe { data.set_len(size as usize) };
-            let nread = try!(libc_wrappers::lgetxattr(real, name.to_owned(), data.as_mut_slice()));
+            let nread = libc_wrappers::lgetxattr(real, name.to_owned(), data.as_mut_slice())?;
             data.truncate(nread);
             Ok(Xattr::Data(data))
         } else {
-            let nbytes = try!(libc_wrappers::lgetxattr(real, name.to_owned(), &mut []));
+            let nbytes = libc_wrappers::lgetxattr(real, name.to_owned(), &mut [])?;
             Ok(Xattr::Size(nbytes as u32))
         }
     }


### PR DESCRIPTION
Update the example code to suit rust 2018 edition.

* no unnecessary `extern crate`
* replace `try!` with `?`
* `crate::`