### PR TITLE
Switch `rust-fuse` to `fuser`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuse_mt"
-version = "0.5.1"
+version = "0.6.0-dev"
 authors = ["William R. Fraser <wfraser@codewise.org>"]
 repository = "https://github.com/wfraser/fuse-mt"
 description = "A higher-level FUSE filesystem library with multi-threading and inode->path translation."
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-fuse = "0.3.1"
+fuse = { git = "https://github.com/zargony/rust-fuse", rev = "54c8405d7b3606082af0e2dfb42f83ee4a50b73a" }
 libc = "0.2"
 log = "0.4"
 threadpool = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,10 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-fuse = { git = "https://github.com/zargony/rust-fuse", rev = "54c8405d7b3606082af0e2dfb42f83ee4a50b73a" }
+fuser = "0.6.0"
 libc = "0.2"
 log = "0.4"
 threadpool = "1.0"
-time = "0.1"
 
 [workspace]
 members = [".", "example"]

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -8,5 +8,4 @@ workspace = ".."
 [dependencies]
 libc = "0.2"
 log = "0.4"
-time = "0.1"
 fuse_mt = { path = ".." }

--- a/example/src/passthrough.rs
+++ b/example/src/passthrough.rs
@@ -11,12 +11,12 @@ use std::io::{self, Read, Write, Seek, SeekFrom};
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::os::unix::io::{FromRawFd, IntoRawFd};
 use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
 
 use crate::libc_extras::libc;
 use crate::libc_wrappers;
 
 use fuse_mt::*;
-use time::*;
 
 pub struct PassthroughFS {
     pub target: OsString,
@@ -40,16 +40,26 @@ fn stat_to_fuse(stat: libc::stat64) -> FileAttr {
     let kind = mode_to_filetype(stat.st_mode);
     let perm = (stat.st_mode & 0o7777) as u16;
 
+    let time = |secs: i64, nanos: i64|
+        SystemTime::UNIX_EPOCH + Duration::new(secs as u64, nanos as u32);
+
+    // libc::nlink_t is wildly different sizes on different platforms:
+    // linux amd64: u64
+    // linux x86:   u32
+    // macOS amd64: u16
+    #[allow(clippy::cast_lossless)]
+    let nlink = stat.st_nlink as u32;
+
     FileAttr {
         size: stat.st_size as u64,
         blocks: stat.st_blocks as u64,
-        atime: Timespec { sec: stat.st_atime as i64, nsec: stat.st_atime_nsec as i32 },
-        mtime: Timespec { sec: stat.st_mtime as i64, nsec: stat.st_mtime_nsec as i32 },
-        ctime: Timespec { sec: stat.st_ctime as i64, nsec: stat.st_ctime_nsec as i32 },
-        crtime: Timespec { sec: 0, nsec: 0 },
+        atime: time(stat.st_atime, stat.st_atime_nsec),
+        mtime: time(stat.st_mtime, stat.st_mtime_nsec),
+        ctime: time(stat.st_ctime, stat.st_ctime_nsec),
+        crtime: SystemTime::UNIX_EPOCH,
         kind,
         perm,
-        nlink: stat.st_nlink as u32,
+        nlink,
         uid: stat.st_uid,
         gid: stat.st_gid,
         rdev: stat.st_rdev as u32,
@@ -109,7 +119,7 @@ impl PassthroughFS {
     }
 }
 
-const TTL: Timespec = Timespec { sec: 1, nsec: 0 };
+const TTL: Duration = Duration::from_secs(1);
 
 impl FilesystemMT for PassthroughFS {
     fn init(&self, _req: RequestInfo) -> ResultEmpty {
@@ -366,15 +376,22 @@ impl FilesystemMT for PassthroughFS {
         }
     }
 
-    fn utimens(&self, _req: RequestInfo, path: &Path, fh: Option<u64>, atime: Option<Timespec>, mtime: Option<Timespec>) -> ResultEmpty {
+    fn utimens(&self, _req: RequestInfo, path: &Path, fh: Option<u64>, atime: Option<SystemTime>, mtime: Option<SystemTime>) -> ResultEmpty {
         debug!("utimens: {:?}: {:?}, {:?}", path, atime, mtime);
 
-
-        fn timespec_to_libc(time: Option<Timespec>) -> libc::timespec {
+        let systemtime_to_libc = |time: Option<SystemTime>| -> libc::timespec {
             if let Some(time) = time {
+                let (secs, nanos) = match time.duration_since(SystemTime::UNIX_EPOCH) {
+                    Ok(duration) => (duration.as_secs() as i64, duration.subsec_nanos()),
+                    Err(in_past) => {
+                        let duration = in_past.duration();
+                        (-(duration.as_secs() as i64), duration.subsec_nanos())
+                    }
+                };
+
                 libc::timespec {
-                    tv_sec: time.sec as libc::time_t,
-                    tv_nsec: libc::time_t::from(time.nsec),
+                    tv_sec: secs,
+                    tv_nsec: i64::from(nanos),
                 }
             } else {
                 libc::timespec {
@@ -382,9 +399,9 @@ impl FilesystemMT for PassthroughFS {
                     tv_nsec: libc::UTIME_OMIT,
                 }
             }
-        }
+        };
 
-        let times = [timespec_to_libc(atime), timespec_to_libc(mtime)];
+        let times = [systemtime_to_libc(atime), systemtime_to_libc(mtime)];
 
         let result = if let Some(fd) = fh {
             unsafe { libc::futimens(fd as libc::c_int, &times as *const libc::timespec) }
@@ -655,8 +672,8 @@ impl FilesystemMT for PassthroughFS {
     fn getxtimes(&self, _req: RequestInfo, path: &Path) -> ResultXTimes {
         debug!("getxtimes: {:?}", path);
         let xtimes = XTimes {
-            bkuptime: Timespec { sec: 0, nsec: 0 },
-            crtime:   Timespec { sec: 0, nsec: 0 },
+            bkuptime: SystemTime::UNIX_EPOCH,
+            crtime:   SystemTime::UNIX_EPOCH,
         };
         Ok(xtimes)
     }

--- a/src/fusemt.rs
+++ b/src/fusemt.rs
@@ -7,9 +7,9 @@
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use threadpool::ThreadPool;
-use time::Timespec;
 
 use crate::directory_cache::*;
 use crate::inode_table::*;
@@ -138,19 +138,19 @@ impl<T: FilesystemMT + Sync + Send + 'static> fuse::Filesystem for FuseMT<T> {
     }
 
     fn setattr(&mut self,
-               req: &fuse::Request<'_>,         // passed to all
-               ino: u64,                    // translated to path; passed to all
-               mode: Option<u32>,           // chmod
-               uid: Option<u32>,            // chown
-               gid: Option<u32>,            // chown
-               size: Option<u64>,           // truncate
-               atime: Option<Timespec>,     // utimens
-               mtime: Option<Timespec>,     // utimens
-               fh: Option<u64>,             // passed to all
-               crtime: Option<Timespec>,    // utimens_osx  (OS X only)
-               chgtime: Option<Timespec>,   // utimens_osx  (OS X only)
-               bkuptime: Option<Timespec>,  // utimens_osx  (OS X only)
-               flags: Option<u32>,          // utimens_osx  (OS X only)
+               req: &fuse::Request<'_>,      // passed to all
+               ino: u64,                     // translated to path; passed to all
+               mode: Option<u32>,            // chmod
+               uid: Option<u32>,             // chown
+               gid: Option<u32>,             // chown
+               size: Option<u64>,            // truncate
+               atime: Option<SystemTime>,    // utimens
+               mtime: Option<SystemTime>,    // utimens
+               fh: Option<u64>,              // passed to all
+               crtime: Option<SystemTime>,   // utimens_osx  (OS X only)
+               chgtime: Option<SystemTime>,  // utimens_osx  (OS X only)
+               bkuptime: Option<SystemTime>, // utimens_osx  (OS X only)
+               flags: Option<u32>,           // utimens_osx  (OS X only)
                reply: fuse::ReplyAttr) {
         let path = get_path!(self, ino, reply);
         debug!("setattr: {:?}", path);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ mod types;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub use fuse::{FileType, mount, spawn_mount};
+pub use fuser::{FileType, mount, spawn_mount};
 
 pub use crate::fusemt::*;
 pub use crate::types::*;

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,8 +5,7 @@
 
 use std::ffi::{OsStr, OsString};
 use std::path::Path;
-
-use time::Timespec;
+use std::time::{Duration, SystemTime};
 
 /// Info about a request.
 #[derive(Clone, Copy, Debug)]
@@ -59,13 +58,13 @@ pub struct FileAttr {
     /// Size in blocks
     pub blocks: u64,
     /// Time of last access
-    pub atime: Timespec,
+    pub atime: SystemTime,
     /// Time of last modification
-    pub mtime: Timespec,
+    pub mtime: SystemTime,
     /// Time of last metadata change
-    pub ctime: Timespec,
+    pub ctime: SystemTime,
     /// Time of creation (macOS only)
-    pub crtime: Timespec,
+    pub crtime: SystemTime,
     /// Kind of file (directory, file, pipe, etc.)
     pub kind: fuse::FileType,
     /// Permissions
@@ -86,7 +85,7 @@ pub struct FileAttr {
 /// the opened file.
 #[derive(Clone, Debug)]
 pub struct CreatedEntry {
-    pub ttl: Timespec,
+    pub ttl: Duration,
     pub attr: FileAttr,
     pub fh: u64,
     pub flags: u32,
@@ -103,12 +102,12 @@ pub enum Xattr {
 #[cfg(target_os = "macos")]
 #[derive(Clone, Debug)]
 pub struct XTimes {
-    pub bkuptime: Timespec,
-    pub crtime: Timespec,
+    pub bkuptime: SystemTime,
+    pub crtime: SystemTime,
 }
 
 pub type ResultEmpty = Result<(), libc::c_int>;
-pub type ResultEntry = Result<(Timespec, FileAttr), libc::c_int>;
+pub type ResultEntry = Result<(Duration, FileAttr), libc::c_int>;
 pub type ResultOpen = Result<(u64, u32), libc::c_int>;
 pub type ResultReaddir = Result<Vec<DirectoryEntry>, libc::c_int>;
 pub type ResultData = Result<Vec<u8>, libc::c_int>;
@@ -183,13 +182,13 @@ pub trait FilesystemMT {
     /// * `fh`: a file handle if this is called on an open file.
     /// * `atime`: the time of last access.
     /// * `mtime`: the time of last modification.
-    fn utimens(&self, _req: RequestInfo, _path: &Path, _fh: Option<u64>, _atime: Option<Timespec>, _mtime: Option<Timespec>) -> ResultEmpty {
+    fn utimens(&self, _req: RequestInfo, _path: &Path, _fh: Option<u64>, _atime: Option<SystemTime>, _mtime: Option<SystemTime>) -> ResultEmpty {
         Err(libc::ENOSYS)
     }
 
     /// Set timestamps of a filesystem entry (with extra options only used on MacOS).
     #[allow(clippy::too_many_arguments)]
-    fn utimens_macos(&self, _req: RequestInfo, _path: &Path, _fh: Option<u64>, _crtime: Option<Timespec>, _chgtime: Option<Timespec>, _bkuptime: Option<Timespec>, _flags: Option<u32>) -> ResultEmpty {
+    fn utimens_macos(&self, _req: RequestInfo, _path: &Path, _fh: Option<u64>, _crtime: Option<SystemTime>, _chgtime: Option<SystemTime>, _bkuptime: Option<SystemTime>, _flags: Option<u32>) -> ResultEmpty {
         Err(libc::ENOSYS)
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -26,7 +26,7 @@ pub struct DirectoryEntry {
     /// Name of the entry
     pub name: OsString,
     /// Kind of file (directory, file, pipe, etc.)
-    pub kind: fuse::FileType,
+    pub kind: crate::FileType,
 }
 
 /// Filesystem statistics.
@@ -66,7 +66,7 @@ pub struct FileAttr {
     /// Time of creation (macOS only)
     pub crtime: SystemTime,
     /// Kind of file (directory, file, pipe, etc.)
-    pub kind: fuse::FileType,
+    pub kind: crate::FileType,
     /// Permissions
     pub perm: u16,
     /// Number of hard links


### PR DESCRIPTION
`rust-fuse` appears to be unmaintained, and its replacement is `fuser`.

This is the minimal set of changes to switch out the crate without changing public types much. The only real change is switching from `timespec` to `std::time::SystemTime` and `std::time::Duration`.

This is a breaking change, though, so the crate minor version gets a bump.