### PR TITLE
WIP: Fix InodeTable issues revealed by xfstests

### DIFF
--- a/src/inode_table.rs
+++ b/src/inode_table.rs
@@ -195,8 +195,8 @@ impl InodeTable {
 
     /// Remove the path->inode mapping for a given path, but keep the inode around.
     pub fn unlink(&mut self, path: &Path) {
-        self.by_path.remove(Pathish::new(path));
-        // Note that the inode->path mapping remains.
+        let idx = self.by_path.remove(Pathish::new(path)).unwrap();
+        self.table[idx].path = None;
     }
 
     /// Get a free indode table entry and its number, either by allocating a new one, or re-using


### PR DESCRIPTION
I am implementing a fuse-fs with a forked fuse-mt, and came across a bug in the inode table replace implementation: when replace is called, the replaced inode retains a record of a path it was originally linked to, and when subsequently kernel orders the filesystem to forget this inode, the path is removed from the `by_path` table, while being associated with another inode, rendering the table inconsistent. This later causes a panic on Option::unwrap in a subsequent `rename`.

The bug is reliably reproduced by the test `generic/011` in the xfstests ([repo](https://github.com/mersinvald/fuse-xfstests/blob/synkro-2019-12/tests/xfs/011))

---

`generic/013` fails in a similar fashion, added a second commit fixing that.

P.S putting a WIP status on the PR, as I now realize there may be other bugs around `inode_table`, that are worth fixing in the same PR.


